### PR TITLE
Domain des AStA Frankfurt hinzugefügt.

### DIFF
--- a/user/public.config.php
+++ b/user/public.config.php
@@ -67,6 +67,10 @@ $allowed_domains = array(
 		'domain'  => 'hebis.de',
 		'desc'    => 'Hessischer Bibliotheksverbund (intensiv genutzt durch Universitätsbibliothek)',
 	),
+	array(
+	    'domain'  => 'asta-frankfurt.de',
+	    'desc'    => 'Allgemeiner Studierendenausschuss der Goethe-Universität',
+	),
 );
 
 # This does not yet work.


### PR DESCRIPTION
Wäre nicht verkehrt auch die Domain des AStA aufzuführen in unserer Whitelist.
